### PR TITLE
Router with nested browser router

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import NavBar from './components/NavBar';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
 import dataset from "./data"
+import { Outlet, RouterProvider, createBrowserRouter } from 'react-router-dom';
 console.log(dataset)
 
 const darkTheme = createTheme({
@@ -14,16 +15,48 @@ const darkTheme = createTheme({
   },
 });
 
+const router = createBrowserRouter(
+  [
+    {
+      path: '/',
+      element: (
+        <>
+          <Outlet />
+          <NavBar />
+        </>
+      ),
+      children: [
+        {
+          index: true,
+          element: <GameSelect />,
+        },
+        {
+          path: '/games',
+          element: <GameSelect />,
+        },
+        {
+          path: '/fighters',
+          element: <CharacterSelect />,
+        },
+        {
+          path: '/fighters/:id',
+          element: <CharacterProfile />,
+        },
+        {
+          path: '/favorites',
+          element: <p>Favorites</p>
+        }
+      ]
+    },
+  ]
+)
+
 export default function App() {
 
   return (
     <ThemeProvider theme={darkTheme}>
       <CssBaseline />
-        <GameSelect />
-        {/* <CharacterSelect /> */}
-        {/* <CharacterProfile /> */}
-
-      <NavBar />
+      <RouterProvider router={router} />
     </ThemeProvider>
   );
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,7 +18,6 @@ const darkTheme = createTheme({
 const router = createBrowserRouter(
   [
     {
-      path: '/',
       element: (
         <>
           <Outlet />

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -22,18 +22,18 @@ export default function NavBar() {
 
   return (
     <Box sx={{ pb: 7 }} >
-      <Paper 
-        sx={{ 
-            position: 'fixed', 
-            bottom: 0, 
-            left: 0, 
+      <Paper
+        sx={{
+            position: 'fixed',
+            bottom: 0,
+            left: 0,
             right: 0
-        }} 
+        }}
         elevation={3}>
 
-        <BottomNavigation 
-          sx={{ bgcolor: '#353535' }} 
-          value={value} 
+        <BottomNavigation
+          sx={{ bgcolor: '#353535' }}
+          value={value}
           onChange={handleChange}>
 
             <BottomNavigationAction
@@ -43,36 +43,36 @@ export default function NavBar() {
               value="/"
               icon={<TempleBuddhistIcon />}
             />
-          
+
             <BottomNavigationAction
               component={Link}
-              to="./pages/GameSelect"
+              to="/games"
               label="Games"
-              value="/game-select"
+              value="/games"
               icon={<SportsEsportsIcon />}
             />
-          
+
             <BottomNavigationAction
               component={Link}
-              to="./pages/CharacterSelect"
+              to="/fighters"
               label="Fighters"
               value="/fighters"
               icon={<SportsMartialArtsIcon />}
             />
-          
+
             <BottomNavigationAction
               component={Link}
-              to="./pages/CharacterProfile"
+              to="/fighters/0"
               label="Combos"
               value="/combos-list"
               icon={<FormatListBulletedIcon />}
             />
-          
+
             <BottomNavigationAction
               component={Link}
-              to="./pages/Favourites"
+              to="/favorites"
               label="Saved"
-              value="/favourites"
+              value="/favorites"
               icon={<StarIcon />}
             />
 

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -3,12 +3,9 @@ import ReactDOM from 'react-dom/client'
 import App from './App.jsx'
 import './Reset.css';
 import './index.css'
-import { BrowserRouter } from 'react-router-dom';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <App />
   </React.StrictMode>,
 )


### PR DESCRIPTION
This uses the fancy new routing available in react-router v6.

The highlights:
- Remove BrowserRouter from index file
- Created a root route that renders the NavBar (doesn't need a path)
- Added all routes as children of the root route
- Used Outlet to render the child routes alongside the NavBar
- Changed nav links to use absolute paths

I've also changed the paths because generally it's good practice to use all lowercase paths, they didn't really need the `/pages` prefix, and spelt "favorites" the American way because there's a lot more American spelling people out there than there are British.

I've also included the `:characterId` route param (that I assume you'll need).

The main magic here is in the use of `<Outlet />` to render child routes. This is a super magic thing, but react-router are really pushing for it.

It might be worth abstracting the root route layout into a `Layout` function component that just renders the NavBar and Outlet (just to keep the code a little tidier).